### PR TITLE
Record history when SH_WORD_SPLIT is enabled

### DIFF
--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -58,7 +58,7 @@ where rowid = (select max(rowid) from history) and session = ${HISTDB_SESSION}"
 zshaddhistory () {
     local cmd="${1[0, -2]}"
 
-    for boring ($_BORING_COMMANDS); do
+    for boring in "${_BORING_COMMANDS[@]}"; do
         if [[ "$cmd" =~ $boring ]]; then
             return 0
         fi


### PR DESCRIPTION
When `SH_WORD_SPLIT` is enabled the `"^ "` regex in `_BORING_COMMANDS` ends up losing its trailing whitespace and expanding as just `"^"`. This ends up matching any command and so no history is recorded. This switches to a more robust parameter expansion when iterating over the array.

```Shell

setopt SH_WORD_SPLIT

TEST=("^ ")

for t ($TEST); do
  if [[ "literally anything" =~ $t ]]; then
    echo "fail";
    return 1;
  fi
done
```