### PR TITLE
Set timeout for sqlite3 command

### DIFF
--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -12,7 +12,7 @@ sql_escape () {
 }
 
 _histdb_query () {
-    sqlite3 "${HISTDB_FILE}" "$@"
+    sqlite3 -cmd ".timeout 1000" "${HISTDB_FILE}" "$@"
     [[ "$?" -ne 0 ]] && echo "error in $@"
 }
 


### PR DESCRIPTION
If multiple shells try to access sqlite database at same time, you can
get a "database is locked" error.  With .timeout set, sqlite will keep
retrying until the timeout has expired.  This should fix the issue that
https://github.com/larkery/zsh-histdb/pull/30 addresses.