### PR TITLE
Declare $_BORING_COMMANDS as global

### DIFF
--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -41,7 +41,7 @@ EOF
     fi
 }
 
-declare -a _BORING_COMMANDS
+declare -ga _BORING_COMMANDS
 _BORING_COMMANDS=("^ls$" "^cd$" "^ " "^histdb" "^top$" "^htop$")
 
 histdb-update-outcome () {


### PR DESCRIPTION
This fixes an issue encountered when loading the plugin via Antigen. The $_BORING_COMMANDS variable will be empty, so every command will be evaluated as "boring" in the `zshaddhistory` hook.