### PR TITLE
_BORING_COMMANDS and HISTDB_TABULATE_CMD have to be global

### DIFF
--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -45,7 +45,7 @@ declare -ga _BORING_COMMANDS
 _BORING_COMMANDS=("^ls$" "^cd$" "^ " "^histdb" "^top$" "^htop$")
 
 if [[ -z "${HISTDB_TABULATE_CMD[*]:-}" ]]; then
-    declare -a HISTDB_TABULATE_CMD
+    declare -ga HISTDB_TABULATE_CMD
     HISTDB_TABULATE_CMD=(column -t -s $'\x1f')
 fi
 


### PR DESCRIPTION
zshaddhistory () always returns 0 because regex matching empty _BORING_COMMANDS array. It was solved for me setting these variables global.