### PR TITLE
Use a separate id instead of rowid

### DIFF
--- a/db_migrations/0to2.sql
+++ b/db_migrations/0to2.sql
@@ -1,0 +1,30 @@
+PRAGMA foreign_keys=OFF;
+begin transaction;
+create table commands_new (id integer primary key autoincrement, argv text, unique(argv) on conflict ignore);
+create table places_new   (id integer primary key autoincrement, host text, dir text, unique(host, dir) on conflict ignore);
+create table history_new  (id integer primary key autoincrement,
+											 session int,
+                       command_id int references commands (id),
+                       place_id int references places (id),
+                       exit_status int,
+                       start_time int,
+                       duration int);
+
+INSERT INTO commands_new (id, argv) SELECT rowid, argv FROM commands;
+INSERT INTO places_new (id, host, dir) SELECT rowid, host, dir FROM places;
+
+INSERT INTO history_new (session, command_id, place_id, exit_status, start_time, duration)
+SELECT H.session, C.rowid, P.rowid, H.exit_status, H.start_time, H.duration
+FROM history H
+LEFT JOIN places P ON H.place_id = P.rowid
+LEFT JOIN commands C ON H.command_id = C.rowid;
+drop table history;
+drop table places;
+drop table commands;
+ALTER TABLE commands_new RENAME TO commands;
+ALTER TABLE places_new RENAME TO places;
+ALTER TABLE history_new RENAME TO history;
+PRAGMA foreign_key_check ;
+PRAGMA user_version=2;
+commit;
+PRAGMA foreign_keys=ON;

--- a/histdb-merge
+++ b/histdb-merge
@@ -19,13 +19,13 @@ INSERT INTO places (host, dir) SELECT host, dir FROM o.places;
 -- could uniquify sessions by host in this way too
 
 INSERT INTO history (session, command_id, place_id, exit_status, start_time, duration)
-SELECT HO.session, C.rowid, P.rowid, HO.exit_status, HO.start_time, HO.duration
+SELECT HO.session, C.rowid, P.id, HO.exit_status, HO.start_time, HO.duration
 FROM o.history HO
-LEFT JOIN o.places PO ON HO.place_id = PO.rowid
-LEFT JOIN o.commands CO ON HO.command_id = CO.rowid
+LEFT JOIN o.places PO ON HO.place_id = PO.id
+LEFT JOIN o.commands CO ON HO.command_id = CO.id
 LEFT JOIN commands C ON C.argv = CO.argv
 LEFT JOIN places P ON (P.host = PO.host
 AND P.dir = PO.dir)
-WHERE HO.rowid > (SELECT MAX(rowid) FROM a.history)
+WHERE HO.id > (SELECT MAX(rowid) FROM a.history)
 ;
 EOF

--- a/histdb-merge
+++ b/histdb-merge
@@ -1,8 +1,14 @@
 #!/usr/bin/env zsh
 
+typeset -g HERE=$(dirname "${(%):-%N}")
+
 local ancestor=${1:?three databases required}; shift
 local ours=${1:?three databases required}; shift
 local theirs=${1:?three databases required}
+
+$HERE/histdb-migrate $ancestor
+$HERE/histdb-migrate $ours
+$HERE/histdb-migrate $theirs
 
 # for reasons I cannot use the encryption filter here.
 # most annoying.

--- a/histdb-merge
+++ b/histdb-merge
@@ -19,7 +19,7 @@ INSERT INTO places (host, dir) SELECT host, dir FROM o.places;
 -- could uniquify sessions by host in this way too
 
 INSERT INTO history (session, command_id, place_id, exit_status, start_time, duration)
-SELECT HO.session, C.rowid, P.id, HO.exit_status, HO.start_time, HO.duration
+SELECT HO.session, C.id, P.id, HO.exit_status, HO.start_time, HO.duration
 FROM o.history HO
 LEFT JOIN o.places PO ON HO.place_id = PO.id
 LEFT JOIN o.commands CO ON HO.command_id = CO.id

--- a/histdb-merge
+++ b/histdb-merge
@@ -6,9 +6,27 @@ local ancestor=${1:?three databases required}; shift
 local ours=${1:?three databases required}; shift
 local theirs=${1:?three databases required}
 
-$HERE/histdb-migrate $ancestor
-$HERE/histdb-migrate $ours
-$HERE/histdb-migrate $theirs
+$HERE/histdb-migrate $ancestor # this is always reasonable to do
+$HERE/histdb-migrate $ours # this also seems fine
+
+V_OURS=$(sqlite3 $ours 'PRAGMA user_version')
+V_THEIRS=$(sqlite3 $theirs 'PRAGMA user_version')
+
+if [[ ${V_OURS} -lt ${V_THEIRS} ]] ; then
+    echo "Attempting to merge with a database from a future version (${V_THEIRS})."
+    echo "You need to update your histdb version to continue."
+    exit 1
+elif [[ ${V_THEIRS} -lt ${V_OURS} ]]; then
+    echo "Merging different database versions: ours ${V_OURS}, theirs ${V_THEIRS}."
+    echo "To continue merging, their database needs migrating to newer version."
+    echo "If you do this, and push the changes, then the remote version of histdb will need upgrading too."
+    
+    read -q "REPLY?Try migrating their database? [y/n] "
+    if [[ $REPLY != "y" ]]; then
+        echo "Cancelled."
+        exit 1
+    fi
+fi
 
 # for reasons I cannot use the encryption filter here.
 # most annoying.

--- a/histdb-migrate
+++ b/histdb-migrate
@@ -1,0 +1,25 @@
+#!/usr/bin/env zsh
+
+typeset -g HISTDB_SCHEMA_VERSION=2
+
+local TARGET_FILE="$1"
+local CURRENT_VERSION=$(sqlite3 "${TARGET_FILE}" 'PRAGMA user_version')
+if [[ ${CURRENT_VERSION} -lt ${HISTDB_SCHEMA_VERSION} ]]; then
+    echo "History database ${TARGET_FILE} is using an older schema (${CURRENT_VERSION}) and will be updated to version ${HISTDB_SCHEMA_VERSION}."
+    local MIGRATION_FILENAME="$(dirname ${HISTDB_INSTALLED_IN})/db_migrations/${CURRENT_VERSION}to${HISTDB_SCHEMA_VERSION}.sql"
+    if [[ -f $MIGRATION_FILENAME ]]; then
+        local BACKUP_FILE="${TARGET_FILE}-$(date +%s).bak"
+        echo "Backing up database to ${BACKUP_FILE} before migration"
+        sqlite3 "${TARGET_FILE}" < "${MIGRATION_FILENAME}"
+        local R="$?"
+        [[ "$R" -ne 0 ]] && (echo "Error during database conversion"; cp ${BACKUP_FILE} ${HISTDB_FILE}) || echo "Update successful (you may want to remove the backup)"
+        return "$R"
+    else
+        echo "There is no migration script from version ${CURRENT_VERSION} to ${HISTDB_SCHEMA_VERSION}."
+        return 1
+    fi
+elif [[ ${CURRENT_VERSION} -gt ${HISTDB_SCHEMA_VERSION} ]]; then
+    echo "History database ${TARGET_FILE} is using a newer schema (${CURRENT_VERSION}) than this version of histdb understands (${HISTDB_SCHEMA_VERSION})."
+    echo "Most likely, you have updated histdb on another machine which has updated your history database, and you need to update this copy of histdb."
+    return 1
+fi

--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -2,9 +2,9 @@ which sqlite3 >/dev/null 2>&1 || return;
 
 typeset -g HISTDB_QUERY=""
 if [[ -z ${HISTDB_FILE} ]]; then
-	typeset -g HISTDB_FILE="${HOME}/.histdb/zsh-history.db"
+    typeset -g HISTDB_FILE="${HOME}/.histdb/zsh-history.db"
 else
-	typeset -g HISTDB_FILE
+    typeset -g HISTDB_FILE
 fi
 typeset -g HISTDB_SESSION=""
 typeset -g HISTDB_HOST=""
@@ -18,32 +18,32 @@ sql_escape () {
 
 _histdb_query () {
     sqlite3 -cmd ".timeout 1000" "${HISTDB_FILE}" "$@"
-    [[ "$?" -ne 0 ]] && echo "error in $@" 
+    [[ "$?" -ne 0 ]] && echo "error in $@"
 }
 
 _histdb_check_version() {
-	local CURRENT_VERSION=$(_histdb_query 'PRAGMA user_version')
-	if [[ ${CURRENT_VERSION} -lt ${HISTDB_SCHEMA_VERSION} ]]; then
-		echo "HISTDB: The schema of the database is to old. Expect errors to happen. Got ${CURRENT_VERSION}, expected ${HISTDB_SCHEMA_VERSION}"
-		echo "HISTDB: Trying to update database"
-		_histdb_update_database
-	fi
-	if [[ ${CURRENT_VERSION} -gt ${HISTDB_SCHEMA_VERSION} ]]; then
-		echo "HISTDB: You are using a newer database schema than expected. Please update histdb. Got ${CURRENT_VERSION}, expected ${HISTDB_SCHEMA_VERSION}"
-	fi
+    local CURRENT_VERSION=$(_histdb_query 'PRAGMA user_version')
+    if [[ ${CURRENT_VERSION} -lt ${HISTDB_SCHEMA_VERSION} ]]; then
+        echo "HISTDB: The schema of the database is to old. Expect errors to happen. Got ${CURRENT_VERSION}, expected ${HISTDB_SCHEMA_VERSION}"
+        echo "HISTDB: Trying to update database"
+        _histdb_update_database
+    fi
+    if [[ ${CURRENT_VERSION} -gt ${HISTDB_SCHEMA_VERSION} ]]; then
+        echo "HISTDB: You are using a newer database schema than expected. Please update histdb. Got ${CURRENT_VERSION}, expected ${HISTDB_SCHEMA_VERSION}"
+    fi
 }
 _histdb_update_database() {
-	local CURRENT_VERSION=$(_histdb_query 'PRAGMA user_version')
-	local MIGRATION_FILENAME="$(dirname ${HISTDB_INSTALLED_IN})/db_migrations/${CURRENT_VERSION}to${HISTDB_SCHEMA_VERSION}.sql"
-	if [[ -f $MIGRATION_FILENAME ]]; then
-		echo "HISTDB: backing up database to ${HISTDB_FILE}.bak"
-		cp ${HISTDB_FILE} ${HISTDB_FILE}.bak
-		echo "HISTDB: applying ${MIGRATION_FILENAME} to ${HISTDB_FILE}"
-		sqlite3 ${HISTDB_FILE} < $MIGRATION_FILENAME
-		[[ "$?" -ne 0 ]] && (echo "HISTDB: error during database conversion";	cp ${HISTDB_FILE}.bak ${HISTDB_FILE}) || echo "HISTDB: update successfull"
-	else
-		echo "HISTDB: no update from ${CURRENT_VERSION} to ${HISTDB_SCHEMA_VERSION} found"
-	fi
+    local CURRENT_VERSION=$(_histdb_query 'PRAGMA user_version')
+    local MIGRATION_FILENAME="$(dirname ${HISTDB_INSTALLED_IN})/db_migrations/${CURRENT_VERSION}to${HISTDB_SCHEMA_VERSION}.sql"
+    if [[ -f $MIGRATION_FILENAME ]]; then
+        echo "HISTDB: backing up database to ${HISTDB_FILE}.bak"
+        cp ${HISTDB_FILE} ${HISTDB_FILE}.bak
+        echo "HISTDB: applying ${MIGRATION_FILENAME} to ${HISTDB_FILE}"
+        sqlite3 ${HISTDB_FILE} < $MIGRATION_FILENAME
+        [[ "$?" -ne 0 ]] && (echo "HISTDB: error during database conversion";   cp ${HISTDB_FILE}.bak ${HISTDB_FILE}) || echo "HISTDB: update successful"
+    else
+        echo "HISTDB: no update from ${CURRENT_VERSION} to ${HISTDB_SCHEMA_VERSION} found"
+    fi
 }
 
 _histdb_init () {
@@ -56,7 +56,7 @@ _histdb_init () {
 create table commands (id integer primary key autoincrement, argv text, unique(argv) on conflict ignore);
 create table places   (id integer primary key autoincrement, host text, dir text, unique(host, dir) on conflict ignore);
 create table history  (id integer primary key autoincrement,
-											 session int,
+                       session int,
                        command_id int references commands (id),
                        place_id int references places (id),
                        exit_status int,
@@ -66,7 +66,7 @@ PRAGMA user_version = 2
 EOF
     fi
     if [[ -z "${HISTDB_SESSION}" ]]; then
-				_histdb_check_version
+        _histdb_check_version
         HISTDB_HOST="'$(sql_escape ${HOST})'"
         HISTDB_SESSION=$(_histdb_query "select 1+max(session) from history inner join places on places.id=history.place_id where places.host = ${HISTDB_HOST}")
         HISTDB_SESSION="${HISTDB_SESSION:-0}"

--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -10,7 +10,6 @@ typeset -g HISTDB_SESSION=""
 typeset -g HISTDB_HOST=""
 typeset -g HISTDB_INSTALLED_IN="${(%):-%N}"
 typeset -g HISTDB_AWAITING_EXIT=0
-typeset -g HISTDB_SCHEMA_VERSION=2
 
 sql_escape () {
     sed -e "s/'/''/g" <<< "$@" | tr -d '\000'
@@ -19,31 +18,6 @@ sql_escape () {
 _histdb_query () {
     sqlite3 -cmd ".timeout 1000" "${HISTDB_FILE}" "$@"
     [[ "$?" -ne 0 ]] && echo "error in $@"
-}
-
-_histdb_check_version() {
-    local CURRENT_VERSION=$(_histdb_query 'PRAGMA user_version')
-    if [[ ${CURRENT_VERSION} -lt ${HISTDB_SCHEMA_VERSION} ]]; then
-        echo "HISTDB: The schema of the database is to old. Expect errors to happen. Got ${CURRENT_VERSION}, expected ${HISTDB_SCHEMA_VERSION}"
-        echo "HISTDB: Trying to update database"
-        _histdb_update_database
-    fi
-    if [[ ${CURRENT_VERSION} -gt ${HISTDB_SCHEMA_VERSION} ]]; then
-        echo "HISTDB: You are using a newer database schema than expected. Please update histdb. Got ${CURRENT_VERSION}, expected ${HISTDB_SCHEMA_VERSION}"
-    fi
-}
-_histdb_update_database() {
-    local CURRENT_VERSION=$(_histdb_query 'PRAGMA user_version')
-    local MIGRATION_FILENAME="$(dirname ${HISTDB_INSTALLED_IN})/db_migrations/${CURRENT_VERSION}to${HISTDB_SCHEMA_VERSION}.sql"
-    if [[ -f $MIGRATION_FILENAME ]]; then
-        echo "HISTDB: backing up database to ${HISTDB_FILE}.bak"
-        cp ${HISTDB_FILE} ${HISTDB_FILE}.bak
-        echo "HISTDB: applying ${MIGRATION_FILENAME} to ${HISTDB_FILE}"
-        sqlite3 ${HISTDB_FILE} < $MIGRATION_FILENAME
-        [[ "$?" -ne 0 ]] && (echo "HISTDB: error during database conversion";   cp ${HISTDB_FILE}.bak ${HISTDB_FILE}) || echo "HISTDB: update successful"
-    else
-        echo "HISTDB: no update from ${CURRENT_VERSION} to ${HISTDB_SCHEMA_VERSION} found"
-    fi
 }
 
 _histdb_init () {
@@ -66,7 +40,7 @@ PRAGMA user_version = 2
 EOF
     fi
     if [[ -z "${HISTDB_SESSION}" ]]; then
-        _histdb_check_version
+        $(dirname ${HISTDB_INSTALLED_IN})/histdb-migrate "${HISTDB_FILE}"
         HISTDB_HOST="'$(sql_escape ${HOST})'"
         HISTDB_SESSION=$(_histdb_query "select 1+max(session) from history inner join places on places.id=history.place_id where places.host = ${HISTDB_HOST}")
         HISTDB_SESSION="${HISTDB_SESSION:-0}"

--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -23,11 +23,12 @@ _histdb_init () {
             mkdir -p -- "$hist_dir"
         fi
         _histdb_query <<-EOF
-create table commands (argv text, unique(argv) on conflict ignore);
-create table places   (host text, dir text, unique(host, dir) on conflict ignore);
-create table history  (session int,
-                       command_id int references commands (rowid),
-                       place_id int references places (rowid),
+create table commands (id integer primary key autoincrement, argv text, unique(argv) on conflict ignore);
+create table places   (id integer primary key autoincrement, host text, dir text, unique(host, dir) on conflict ignore);
+create table history  (id integer primary key autoincrement,
+											 session int,
+                       command_id int references commands (id),
+                       place_id int references places (id),
                        exit_status int,
                        start_time int,
                        duration int);
@@ -35,7 +36,7 @@ EOF
     fi
     if [[ -z "${HISTDB_SESSION}" ]]; then
         HISTDB_HOST="'$(sql_escape ${HOST})'"
-        HISTDB_SESSION=$(_histdb_query "select 1+max(session) from history inner join places on places.rowid=history.place_id where places.host = ${HISTDB_HOST}")
+        HISTDB_SESSION=$(_histdb_query "select 1+max(session) from history inner join places on places.id=history.place_id where places.host = ${HISTDB_HOST}")
         HISTDB_SESSION="${HISTDB_SESSION:-0}"
         readonly HISTDB_SESSION
     fi
@@ -55,7 +56,7 @@ histdb-update-outcome () {
     if [[ $HISTDB_AWAITING_EXIT == 1 ]]; then
         _histdb_init
         _histdb_query "update history set exit_status = ${retval}, duration = ${finished} - start_time
-where rowid = (select max(rowid) from history) and session = ${HISTDB_SESSION}"
+where id = (select max(id) from history) and session = ${HISTDB_SESSION}"
         HISTDB_AWAITING_EXIT=0
     fi
 }
@@ -82,8 +83,8 @@ insert into history
   (session, command_id, place_id, start_time)
 select
   ${HISTDB_SESSION},
-  commands.rowid,
-  places.rowid,
+  commands.id,
+  places.id,
   ${started}
 from
   commands, places
@@ -107,12 +108,12 @@ histdb-top () {
     case "$1" in
         dir)
             field=places.dir
-            join='places.rowid = history.place_id'
+            join='places.id = history.place_id'
             table=places
             ;;
         cmd)
             field=commands.argv
-            join='commands.rowid = history.command_id'
+            join='commands.id = history.command_id'
             table=commands
             ;;;
     esac
@@ -120,7 +121,7 @@ histdb-top () {
             -header \
             "select count(*) as count, places.host, replace($field, '
 ', '
-$sep$sep') as ${1:-cmd} from history left join commands on history.command_id=commands.rowid left join places on history.place_id=places.rowid group by places.host, $field order by count(*)" | \
+$sep$sep') as ${1:-cmd} from history left join commands on history.command_id=commands.id left join places on history.place_id=places.id group by places.host, $field order by count(*)" | \
         "${HISTDB_TABULATE_CMD[@]}"
 }
 
@@ -313,8 +314,8 @@ $seps') as argv, max(start_time) as max_start"
     local query="select ${selcols} from (select ${cols}
 from
   history
-  left join commands on history.command_id = commands.rowid
-  left join places on history.place_id = places.rowid
+  left join commands on history.command_id = commands.id
+  left join places on history.place_id = places.id
 where ${where}
 group by history.command_id, history.place_id
 order by max_start desc
@@ -324,8 +325,8 @@ ${limit:+limit $limit}) order by max_start asc"
     local count_query="select count(*) from (select ${cols}
 from
   history
-  left join commands on history.command_id = commands.rowid
-  left join places on history.place_id = places.rowid
+  left join commands on history.command_id = commands.id
+  left join places on history.place_id = places.id
 where ${where}
 group by history.command_id, history.place_id
 order by max_start desc) order by max_start asc"
@@ -359,13 +360,13 @@ order by max_start desc) order by max_start asc"
         read -q "REPLY?Forget all these results? [y/n] "
         if [[ $REPLY =~ "[yY]" ]]; then
             _histdb_query "delete from history where
-history.rowid in (
-select history.rowid from
+history.id in (
+select history.id from
 history
-  left join commands on history.command_id = commands.rowid
-  left join places on history.place_id = places.rowid
+  left join commands on history.command_id = commands.id
+  left join places on history.place_id = places.id
 where ${where})"
-            _histdb_query "delete from commands where commands.rowid not in (select distinct history.command_id from history)"
+            _histdb_query "delete from commands where commands.id not in (select distinct history.command_id from history)"
         fi
     fi
 }


### PR DESCRIPTION
This will add a separate column id to all tables.
Additionally it supports automated db migrations to perform the update of the schema.

Fixes #40.
