### PR TITLE
Allow setting of a histdb file

### DIFF
--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -1,7 +1,11 @@
 which sqlite3 >/dev/null 2>&1 || return;
 
 typeset -g HISTDB_QUERY=""
-typeset -g HISTDB_FILE="${HOME}/.histdb/zsh-history.db"
+if [[ -z ${HISTDB_FILE} ]]; then
+	typeset -g HISTDB_FILE="${HOME}/.histdb/zsh-history.db"
+else
+	typeset -g HISTDB_FILE
+fi
 typeset -g HISTDB_SESSION=""
 typeset -g HISTDB_HOST=""
 typeset -g HISTDB_INSTALLED_IN="${(%):-%N}"


### PR DESCRIPTION
Using classic if HISTDB_FILE is a non empty string use it mechanism to
let the user set its own file location.

solves: https://github.com/larkery/zsh-histdb/issues/5