### PR TITLE
Allow to select sorting order

### DIFF
--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -237,10 +237,14 @@ histdb () {
     fi
 
     local sep=$'\x1f'
+    local orderdir='asc'
     local debug=0
     local opt=""
     for opt ($opts); do
         case $opt in
+            --desc)
+                orderdir='desc'
+                ;;
             --sep*)
                 sep=${opt#--sep}
                 ;;
@@ -327,7 +331,7 @@ from
 where ${where}
 group by history.command_id, history.place_id
 order by max_start desc
-${limit:+limit $limit}) order by max_start asc"
+${limit:+limit $limit}) order by max_start ${orderdir}"
 
     ## min max date?
     local count_query="select count(*) from (select ${cols}
@@ -337,7 +341,7 @@ from
   left join places on history.place_id = places.id
 where ${where}
 group by history.command_id, history.place_id
-order by max_start desc) order by max_start asc"
+order by max_start desc) order by max_start ${orderdir}"
 
     if [[ $debug = 1 ]]; then
         echo "$query"


### PR DESCRIPTION
Adding a parameter --desc to switch from ascending to descending sorting
order in the histdb command.