### PR TITLE
Do not create session without command

### DIFF
--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -58,6 +58,7 @@ fi
 histdb-update-outcome () {
     local retval=$?
     local finished=$(date +%s)
+    [[ -z "${HISTDB_SESSION}" ]] && return
 
     _histdb_init
     _histdb_query <<EOF


### PR DESCRIPTION
This will prohibit the creation of a session id in case there has not
been entered a command. Else it may mess up the sessions and mix their
commands. This will happen if you create two shells and do not fire a
command in between in the newly created one.