### PR TITLE
Use where="1" so that it can support lower version of sqlite3.

### DIFF
--- a/README.org
+++ b/README.org
@@ -26,7 +26,7 @@ It is also possible to merge multiple history databases together without conflic
 
 * Installation
 
-You will need ~sqlite3~ (*version* > 3.23.0) and the usual coreutils commands installed on your ~PATH~.
+You will need ~sqlite3~ and the usual coreutils commands installed on your ~PATH~.
 To load and activate history recording you need to source ~sqlite-history.zsh~ from your shell in your zsh startup files.
 
 If you want the history to contain correct timing information, you will also need to run ~histdb-update-outcome~ in your ~precmd~ hook

--- a/README.org
+++ b/README.org
@@ -26,7 +26,7 @@ It is also possible to merge multiple history databases together without conflic
 
 * Installation
 
-You will need ~sqlite3~ and the usual coreutils commands installed on your ~PATH~.
+You will need ~sqlite3~ (*version* > 3.23.0) and the usual coreutils commands installed on your ~PATH~.
 To load and activate history recording you need to source ~sqlite-history.zsh~ from your shell in your zsh startup files.
 
 If you want the history to contain correct timing information, you will also need to run ~histdb-update-outcome~ in your ~precmd~ hook

--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -200,7 +200,7 @@ histdb () {
 
     local selcols="session as ses, dir"
     local cols="session, replace(places.dir, '$HOME', '~') as dir"
-    local where="true"
+    local where="1"
     if [[ -p /dev/stdout ]]; then
         local limit=""
     else


### PR DESCRIPTION
I tried to install this plugin on my vm.
Found an error with `Error: no such column: true`.
![image](https://user-images.githubusercontent.com/1673006/68090782-e4563700-feb2-11e9-9b5a-3fca159607e2.png)

Spend quite a few time on this issue. Turns out it's quite easy. The sqlite3 **version** need to be > 3.23.0.
> https://stackoverflow.com/questions/2510652/is-there-a-boolean-literal-in-sqlite

I think it is necessary to add it to the readme, help people like me to save some time.