### PR TITLE
Add oh-my-zsh plugin file

### DIFF
--- a/zsh-histdb.plugin.zsh
+++ b/zsh-histdb.plugin.zsh
@@ -1,0 +1,1 @@
+source ${0:A:h}/sqlite-history.zsh


### PR DESCRIPTION
This allows for the histdb script to be loaded with oh-my-zsh. Useful for use in tandem with https://github.com/zsh-users/zsh-completions