### PR TITLE
Use single sqlite process per shell to reduce fsync contention

### DIFF
--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -10,6 +10,9 @@ typeset -g HISTDB_SESSION=""
 typeset -g HISTDB_HOST=""
 typeset -g HISTDB_INSTALLED_IN="${(%):-%N}"
 
+coproc sqlite3 -batch "${HISTDB_FILE}" >/dev/null
+trap "coproc exit" EXIT HUP TERM INT
+
 sql_escape () {
     sed -e "s/'/''/g" <<< "$@" | tr -d '\000'
 }
@@ -17,6 +20,10 @@ sql_escape () {
 _histdb_query () {
     sqlite3 -cmd ".timeout 1000" "${HISTDB_FILE}" "$@"
     [[ "$?" -ne 0 ]] && echo "error in $@"
+}
+
+_histdb_query_batch () {
+    cat >&p
 }
 
 _histdb_init () {
@@ -29,7 +36,7 @@ _histdb_init () {
         if ! [[ -d "$hist_dir" ]]; then
             mkdir -p -- "$hist_dir"
         fi
-        _histdb_query <<-EOF
+        _histdb_query_batch <<-EOF
 create table commands (id integer primary key autoincrement, argv text, unique(argv) on conflict ignore);
 create table places   (id integer primary key autoincrement, host text, dir text, unique(host, dir) on conflict ignore);
 create table history  (id integer primary key autoincrement,
@@ -39,7 +46,7 @@ create table history  (id integer primary key autoincrement,
                        exit_status int,
                        start_time int,
                        duration int);
-PRAGMA user_version = 2
+PRAGMA user_version = 2;
 EOF
     fi
     if [[ -z "${HISTDB_SESSION}" ]]; then
@@ -50,12 +57,13 @@ EOF
         readonly HISTDB_SESSION
     fi
 
-    _histdb_query >/dev/null <<EOF
+    _histdb_query_batch >/dev/null <<EOF
 create index if not exists hist_time on history(start_time);
 create index if not exists place_dir on places(dir);
 create index if not exists place_host on places(host);
 create index if not exists history_command_place on history(command_id, place_id);
 PRAGMA journal_mode = WAL;
+PRAGMA synchronous=normal;
 EOF
 }
 
@@ -72,7 +80,7 @@ histdb-update-outcome () {
     local finished=$(date +%s)
 
     _histdb_init
-    _histdb_query <<EOF &|
+    _histdb_query_batch <<EOF &|
 update history set 
       exit_status = ${retval}, 
       duration = ${finished} - start_time
@@ -97,8 +105,8 @@ zshaddhistory () {
     _histdb_init
 
     if [[ "$cmd" != "''" ]]; then
-        _histdb_query \
-            "insert into commands (argv) values (${cmd});
+        _histdb_query_batch <<EOF &|
+insert into commands (argv) values (${cmd});
 insert into places   (host, dir) values (${HISTDB_HOST}, ${pwd});
 insert into history
   (session, command_id, place_id, start_time)
@@ -113,7 +121,8 @@ where
   commands.argv = ${cmd} and
   places.host = ${HISTDB_HOST} and
   places.dir = ${pwd}
-;" &|
+;
+EOF
     fi
     return 0
 }


### PR DESCRIPTION
Thanks to @phiresky for this.