### PR TITLE
rename start_sqlite_pipe function, add info to readme

### DIFF
--- a/README.org
+++ b/README.org
@@ -51,7 +51,7 @@ in your zsh startup files.
 
 ** Importing your old history
 
-https://github.com/drewis/go-histdbimport is a useful tool for doing this!
+[[https://github.com/drewis/go-histdbimport][go-histdbimport]] and [[https://github.com/phiresky/ts-histdbimport][ts-histdbimport]] are useful tools for doing this! Note that the imported history will not include metadata such as the working directory or the exit status, since that is not stored in the normal history file format, so queries using ~--in DIR~, etc. will not work as expected.
 
 * Querying history
 You can query the history with the ~histdb~ command.

--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -21,7 +21,7 @@ _histdb_query () {
     [[ "$?" -ne 0 ]] && echo "error in $@"
 }
 
-start_sqlite_pipe () {
+_histdb_start_sqlite_pipe () {
     local PIPE=$(mktemp -u)
     setopt local_options no_notify no_monitor
     mkfifo $PIPE
@@ -31,7 +31,7 @@ start_sqlite_pipe () {
     zshexit() { exec {HISTDB_FD}>&-; } # https://stackoverflow.com/a/22794374/2639190
 }
 
-start_sqlite_pipe
+_histdb_start_sqlite_pipe
 
 _histdb_query_batch () {
     cat >&$HISTDB_FD


### PR DESCRIPTION
I've renamed the start_sqlite_pipe function since I've realized that function is globally available in the shell and the name is really generic.

I've also added an alternativeand to histdbimport that is much faster and more info to the readme.

These two changes are unrelated, one PR for convenience. Let me know I should split them.