### PR TITLE
histdb-sync: flush write-ahead-log before syncing

### DIFF
--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -181,6 +181,7 @@ histdb-sync () {
             git add .gitattributes .gitignore
             git add "$(basename ${HISTDB_FILE})"
         fi
+        _histdb_query "PRAGMA wal_checkpoint(RESTART)" >/dev/null && \
         git commit -am "history" && git pull --no-edit && git push
         popd > /dev/null
     fi

--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -20,7 +20,7 @@ sql_escape () {
 
 _histdb_query () {
     sqlite3 -cmd ".timeout 1000" "${HISTDB_FILE}" "$@"
-    [[ "$?" -ne 0 ]] && echo "error in $@"
+    [[ "$?" -eq 0 ]] || (echo "error in $@" && false)
 }
 
 _histdb_start_sqlite_pipe () {

--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -172,7 +172,7 @@ histdb-sync () {
     _histdb_init
     local hist_dir="$(dirname ${HISTDB_FILE})"
     if [[ -d "$hist_dir" ]]; then
-        pushd "$hist_dir"
+        pushd "$hist_dir" > /dev/null
         if [[ $(git rev-parse --is-inside-work-tree) != "true" ]] || [[ "$(git rev-parse --show-toplevel)" != "$(pwd)" ]]; then
             git init
             git config merge.histdb.driver "$(dirname ${HISTDB_INSTALLED_IN})/histdb-merge %O %A %B"
@@ -182,7 +182,7 @@ histdb-sync () {
             git add "$(basename ${HISTDB_FILE})"
         fi
         git commit -am "history" && git pull --no-edit && git push
-        popd
+        popd > /dev/null
     fi
 }
 

--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -177,7 +177,8 @@ histdb-sync () {
             git init
             git config merge.histdb.driver "$(dirname ${HISTDB_INSTALLED_IN})/histdb-merge %O %A %B"
             echo "$(basename ${HISTDB_FILE}) merge=histdb" | tee -a .gitattributes &>-
-            git add .gitattributes
+            echo -e "*.db-shm\n*.db-wal" > .gitignore
+            git add .gitattributes .gitignore
             git add "$(basename ${HISTDB_FILE})"
         fi
         git commit -am "history" && git pull --no-edit && git push


### PR DESCRIPTION
Hi,

New user of zsh-histdb. So far I love it. However I ran into issues when testing the history sync between computers - sometimes sqlite would complain about the database being corrupt, and all hell break loose. I tracked this down to having some history not written in the db yet, but instead residing in this .db-wal file - when the .db file is overwritten by the histdb-sync, the wal file no longer refers to the correct db version, and sqlite gets confused and angry.

Or, in more words:

As a performance optimization, sqlite's write-ahead log (wal) was
enabled in 873610f1, which means writes are appended to this .db-wal
file  and only written to the actual .db file after a lot of writes or
when the db connection is closed (which, since a4a60e3b7a, happens only
on zsh exit). However, only the .db file is tracked by git, the wal
being nothing but a temporary cache.

This brings a few issues:

- Recent commands, only in the wal, aren't committed by histdb-sync
- If an update is pulled and the .db file modified, but pending changes
  are still in the wal, sqlite gets very confused and interprets it as a
  corrupt database. Fixing this requires closing the db connection (aka
  the whole shell) and deleting the wal, loosing the last bits of
  history for all sessions.
    - Of course, if you have multiple terminals open, you must do it for
      all of them.

Note this still commit merely shortens significantly the histdb-sync/wal
race condition window - a command typed in another terminal during the
sync could still write to the wal and cause issues. However, working
around that is a bit more involved and probably implies locking the
whole database during the sync, which might bring other issues, and at
that point, the question of whether the wal perf. increase is worth it.