### PR TITLE
histdb-sync: Don't run git init all the time if $HISTDB_FILE contains symlink

### DIFF
--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -173,7 +173,7 @@ histdb-sync () {
     local hist_dir="$(dirname ${HISTDB_FILE})"
     if [[ -d "$hist_dir" ]]; then
         pushd "$hist_dir"
-        if [[ $(git rev-parse --is-inside-work-tree) != "true" ]] || [[ "$(git rev-parse --show-toplevel)" != "$(pwd)" ]]; then
+        if [[ $(git rev-parse --is-inside-work-tree) != "true" ]] || [[ "$(git rev-parse --show-toplevel)" != "$(pwd -P)" ]]; then
             git init
             git config merge.histdb.driver "$(dirname ${HISTDB_INSTALLED_IN})/histdb-merge %O %A %B"
             echo "$(basename ${HISTDB_FILE}) merge=histdb" | tee -a .gitattributes &>-


### PR DESCRIPTION
If $HISTDB_FILE's path contains a symlink, the
`[[ "$(git rev-parse --show-toplevel)" != "$(pwd)" ]]` comparison
returns false because show-toplevel returns the physical path to the
directory (ie. with symlinks resolved) while pwd returns the logical path
(ie. without resolving symlinks).

Instead, use pwd -P to get the physical path of the current directory and compare apples to apples.