### PR TITLE
Ensure zstat is available

### DIFF
--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -1,6 +1,7 @@
 which sqlite3 >/dev/null 2>&1 || return;
 
 zmodload zsh/system # for sysopen
+zmodload zsh/stat # for zstat
 autoload -U add-zsh-hook
 
 typeset -g HISTDB_QUERY=""


### PR DESCRIPTION
On macOS at least, the `zstat` function isn't available unless it's explicitly loaded.