### PR TITLE
fix rowid in merge

### DIFF
--- a/histdb-merge
+++ b/histdb-merge
@@ -50,6 +50,6 @@ LEFT JOIN o.commands CO ON HO.command_id = CO.id
 LEFT JOIN commands C ON C.argv = CO.argv
 LEFT JOIN places P ON (P.host = PO.host
 AND P.dir = PO.dir)
-WHERE HO.id > (SELECT MAX(rowid) FROM a.history)
+WHERE HO.id > (SELECT MAX(id) FROM a.history)
 ;
 EOF


### PR DESCRIPTION
There was one more use of rowid which may lead to data loss/duplication during a merge.