### PR TITLE
Allow re-defining HISTDB_HOST

### DIFF
--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -90,7 +90,7 @@ EOF
     fi
     if [[ -z "${HISTDB_SESSION}" ]]; then
         $(dirname ${HISTDB_INSTALLED_IN})/histdb-migrate "${HISTDB_FILE}"
-        HISTDB_HOST="'$(sql_escape ${HOST})'"
+        HISTDB_HOST=${HISTDB_HOST:-"'$(sql_escape ${HOST})'"}
         HISTDB_SESSION=$(_histdb_query "select 1+max(session) from history inner join places on places.id=history.place_id where places.host = ${HISTDB_HOST}")
         HISTDB_SESSION="${HISTDB_SESSION:-0}"
         readonly HISTDB_SESSION


### PR DESCRIPTION
This change allows the hostname to be modified after sourcing zsh-histdb, e.g. to change it to user@host:

	source zsh-histdb/sqlite-history.zsh
	HISTDB_HOST="'$(sql_escape ${USER}@${HOST})'"

My use-case is for merging history of multiple hosts where I may have multiple users on each host. Reassigning doesn't work without this change because init happens later.