### PR TITLE
Prevent creation of empty `-` file in histdb-sync

### DIFF
--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -211,7 +211,7 @@ histdb-sync () {
         if [[ $(git rev-parse --is-inside-work-tree) != "true" ]] || [[ "$(git rev-parse --show-toplevel)" != "$(pwd -P)" ]]; then
             git init
             git config merge.histdb.driver "$(dirname ${HISTDB_INSTALLED_IN})/histdb-merge %O %A %B"
-            echo "$(basename ${HISTDB_FILE}) merge=histdb" | tee -a .gitattributes &>-
+            echo "$(basename ${HISTDB_FILE}) merge=histdb" | tee -a .gitattributes &>/dev/null
             git add .gitattributes
             git add "$(basename ${HISTDB_FILE})"
         fi


### PR DESCRIPTION
Output of tee is now directed to `/dev/null` so that no `-` file is created.