### PR TITLE
Fix pushd/popd in histdb-sync

### DIFF
--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -207,20 +207,20 @@ histdb-sync () {
     
     local hist_dir="$(dirname ${HISTDB_FILE})"
     if [[ -d "$hist_dir" ]]; then
-        local restore_dir=0
-        if [[ "${hist_dir}" != "${PWD}" ]]; then
+        () {
+            setopt local_options no_pushd_ignore_dups
+
             pushd -q "$hist_dir"
-            restore_dir=1
-        fi
-        if [[ $(git rev-parse --is-inside-work-tree) != "true" ]] || [[ "$(git rev-parse --show-toplevel)" != "$(pwd -P)" ]]; then
-            git init
-            git config merge.histdb.driver "$(dirname ${HISTDB_INSTALLED_IN})/histdb-merge %O %A %B"
-            echo "$(basename ${HISTDB_FILE}) merge=histdb" | tee -a .gitattributes &>-
-            git add .gitattributes
-            git add "$(basename ${HISTDB_FILE})"
-        fi
-        git commit -am "history" && git pull --no-edit && git push
-        (( restore_dir )) && popd -q
+            if [[ $(git rev-parse --is-inside-work-tree) != "true" ]] || [[ "$(git rev-parse --show-toplevel)" != "$(pwd -P)" ]]; then
+                git init
+                git config merge.histdb.driver "$(dirname ${HISTDB_INSTALLED_IN})/histdb-merge %O %A %B"
+                echo "$(basename ${HISTDB_FILE}) merge=histdb" | tee -a .gitattributes &>-
+                git add .gitattributes
+                git add "$(basename ${HISTDB_FILE})"
+            fi
+            git commit -am "history" && git pull --no-edit && git push
+            popd -q
+        }
     fi
 
     echo 'pragma wal_checkpoint(passive);' | _histdb_query_batch

--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -207,7 +207,7 @@ histdb-sync () {
     
     local hist_dir="$(dirname ${HISTDB_FILE})"
     if [[ -d "$hist_dir" ]]; then
-        pushd "$hist_dir"
+        pushd -q "$hist_dir"
         if [[ $(git rev-parse --is-inside-work-tree) != "true" ]] || [[ "$(git rev-parse --show-toplevel)" != "$(pwd -P)" ]]; then
             git init
             git config merge.histdb.driver "$(dirname ${HISTDB_INSTALLED_IN})/histdb-merge %O %A %B"
@@ -216,7 +216,7 @@ histdb-sync () {
             git add "$(basename ${HISTDB_FILE})"
         fi
         git commit -am "history" && git pull --no-edit && git push
-        popd
+        popd -q
     fi
 
     echo 'pragma wal_checkpoint(passive);' | _histdb_query_batch

--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -207,7 +207,11 @@ histdb-sync () {
     
     local hist_dir="$(dirname ${HISTDB_FILE})"
     if [[ -d "$hist_dir" ]]; then
-        pushd -q "$hist_dir"
+        local restore_dir=0
+        if [[ "${hist_dir}" != "${PWD}" ]]; then
+            pushd -q "$hist_dir"
+            restore_dir=1
+        fi
         if [[ $(git rev-parse --is-inside-work-tree) != "true" ]] || [[ "$(git rev-parse --show-toplevel)" != "$(pwd -P)" ]]; then
             git init
             git config merge.histdb.driver "$(dirname ${HISTDB_INSTALLED_IN})/histdb-merge %O %A %B"
@@ -216,7 +220,7 @@ histdb-sync () {
             git add "$(basename ${HISTDB_FILE})"
         fi
         git commit -am "history" && git pull --no-edit && git push
-        popd -q
+        (( restore_dir )) && popd -q
     fi
 
     echo 'pragma wal_checkpoint(passive);' | _histdb_query_batch


### PR DESCRIPTION
When `histdb-sync` is run inside `$hist_dir`, `pushd` won't produce a new directory on the stack and `popd` will throw us out of the current directory. This PR addresses that and also adds the `-q` flag to `pushd` and `popd` which e.g. prevents execution of `chpwd` hooks.