### PR TITLE
Do not expose HISTDB_FILE path via `ps`

### DIFF
--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -49,7 +49,9 @@ _histdb_start_sqlite_pipe () {
     local PIPE=$(mktemp -u)
     setopt local_options no_notify no_monitor
     mkfifo $PIPE
-    sqlite3 -batch "${HISTDB_FILE}" < $PIPE >/dev/null &|
+    pushd -q "${HISTDB_FILE:h}"
+    sqlite3 -batch "${HISTDB_FILE:t}" < $PIPE >/dev/null &|
+    popd -q
     sysopen -w -o cloexec -u HISTDB_FD -- $PIPE
     command rm $PIPE
     HISTDB_INODE=$(zstat +inode ${HISTDB_FILE})


### PR DESCRIPTION
Sorry for spamming the PRs 😅. Anyway, this is a "nice to have", not an issue per-se, so I'll understand if it's of no interest to you to merge. 

I prefer not to expose the full path of `$HISTDB_FILE` to process monitors. The use case for this is shared systems mostly where I might not want to expose the full path to the file. With this PR, the following:

```
sqlite3 -batch /Users/maf/.histdb/zsh-history.db
```

becomes: 

```
sqlite3 -batch zsh-history.db
```

It's just neater (IMO) and doesn't expose custom paths if I were to load it from another place.