### PR TITLE
Guard against zsh older than 5.0.8

### DIFF
--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -1,6 +1,8 @@
 which sqlite3 >/dev/null 2>&1 || return;
 
 zmodload zsh/system # for sysopen
+which sysopen &>/dev/null || return; # guard against zsh older than 5.0.8.
+
 zmodload -F zsh/stat b:zstat # just zstat
 autoload -U add-zsh-hook
 


### PR DESCRIPTION
The sysopen built-in was added in 5.0.8 so `_histdb_start_sqlite_pipe` will fail on older versions.