### PR TITLE
Use the built-in which to detect other built-ins

### DIFF
--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -1,7 +1,7 @@
 which sqlite3 >/dev/null 2>&1 || return;
 
 zmodload zsh/system # for sysopen
-which sysopen &>/dev/null || return; # guard against zsh older than 5.0.8.
+builtin which sysopen &>/dev/null || return; # guard against zsh older than 5.0.8.
 
 zmodload -F zsh/stat b:zstat # just zstat
 autoload -U add-zsh-hook
@@ -71,7 +71,7 @@ _histdb_init () {
     if [[ -n "${HISTDB_SESSION}" ]]; then
         return
     fi
-    
+
     if ! [[ -e "${HISTDB_FILE}" ]]; then
         local hist_dir="$(dirname ${HISTDB_FILE})"
         if ! [[ -d "$hist_dir" ]]; then
@@ -124,10 +124,10 @@ _histdb_update_outcome () {
 
     _histdb_init
     _histdb_query_batch <<EOF &|
-update history set 
-      exit_status = ${retval}, 
+update history set
+      exit_status = ${retval},
       duration = ${finished} - start_time
-where id = (select max(id) from history) and 
+where id = (select max(id) from history) and
       session = ${HISTDB_SESSION} and
       exit_status is NULL;
 EOF
@@ -206,7 +206,7 @@ histdb-sync () {
     # this ought to apply to other readers?
     echo "truncating WAL"
     echo 'pragma wal_checkpoint(truncate);' | _histdb_query_batch
-    
+
     local hist_dir="$(dirname ${HISTDB_FILE})"
     if [[ -d "$hist_dir" ]]; then
         () {
@@ -427,10 +427,10 @@ $seps') as argv, max(start_time) as max_start"
     if [[ $orderdir == "asc" ]]; then
         r_order="desc"
     fi
-    
+
     local query="select ${selcols} from (select ${cols}
 from
-  commands 
+  commands
   join history on history.command_id = commands.id
   join places on history.place_id = places.id
 where ${where}


### PR DESCRIPTION
This is a fix for issue #109 

On some systems, the built-in `which` has been overridden with an alias that does not properly detect other built-ins. So we have to ensure we are using the built-in `which` to safely detect the built-in `sysopen`.

Sorry the diff is so dirty. The file had a bunch of unnecessary white space that my editor removed automatically.