### PR TITLE
Fix sqlite batch usage

### DIFF
--- a/histdb-merge
+++ b/histdb-merge
@@ -9,8 +9,8 @@ local theirs=${1:?three databases required}
 $HERE/histdb-migrate $ancestor # this is always reasonable to do
 $HERE/histdb-migrate $ours # this also seems fine
 
-V_OURS=$(sqlite3 $ours 'PRAGMA user_version')
-V_THEIRS=$(sqlite3 $theirs 'PRAGMA user_version')
+V_OURS=$(sqlite3 -batch -noheader $ours 'PRAGMA user_version')
+V_THEIRS=$(sqlite3 -batch -noheader $theirs 'PRAGMA user_version')
 
 if [[ ${V_OURS} -lt ${V_THEIRS} ]] ; then
     echo "Attempting to merge with a database from a future version (${V_THEIRS})."
@@ -31,7 +31,7 @@ fi
 # for reasons I cannot use the encryption filter here.
 # most annoying.
 
-sqlite3 "${ours}" <<EOF
+sqlite3 -batch -noheader "${ours}" <<EOF
 ATTACH DATABASE '${theirs}' AS o;
 ATTACH DATABASE '${ancestor}' AS a;
 

--- a/histdb-migrate
+++ b/histdb-migrate
@@ -4,7 +4,7 @@ typeset -g HISTDB_SCHEMA_VERSION=2
 typeset -g HISTDB_INSTALLED_IN="${(%):-%N}"
 
 local TARGET_FILE="$1"
-local CURRENT_VERSION=$(sqlite3 "${TARGET_FILE}" 'PRAGMA user_version')
+local CURRENT_VERSION=$(sqlite3 -batch -noheader "${TARGET_FILE}" 'PRAGMA user_version')
 if [[ ${CURRENT_VERSION} -lt ${HISTDB_SCHEMA_VERSION} ]]; then
     echo "History database ${TARGET_FILE} is using an older schema (${CURRENT_VERSION}) and will be updated to version ${HISTDB_SCHEMA_VERSION}."
     local MIGRATION_FILENAME="$(dirname ${HISTDB_INSTALLED_IN})/db_migrations/${CURRENT_VERSION}to${HISTDB_SCHEMA_VERSION}.sql"
@@ -12,7 +12,7 @@ if [[ ${CURRENT_VERSION} -lt ${HISTDB_SCHEMA_VERSION} ]]; then
         local BACKUP_FILE="${TARGET_FILE}-$(date +%s).bak"
         echo "Backing up database to ${BACKUP_FILE} before migration"
         cp ${BACKUP_FILE} ${HISTDB_FILE}
-        sqlite3 "${TARGET_FILE}" < "${MIGRATION_FILENAME}"
+        sqlite3 -batch -noheader "${TARGET_FILE}" < "${MIGRATION_FILENAME}"
         local R="$?"
         [[ "$R" -ne 0 ]] && (echo "Error during database conversion"; cp ${BACKUP_FILE} ${HISTDB_FILE}) || echo "Update successful (you may want to remove the backup)"
         return "$R"

--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -25,7 +25,7 @@ sql_escape () {
 }
 
 _histdb_query () {
-    sqlite3 -cmd ".timeout 1000" "${HISTDB_FILE}" "$@"
+    sqlite3 -batch -noheader -cmd ".timeout 1000" "${HISTDB_FILE}" "$@"
     [[ "$?" -ne 0 ]] && echo "error in $@"
 }
 
@@ -51,7 +51,7 @@ _histdb_start_sqlite_pipe () {
     local PIPE=$(mktemp -u)
     setopt local_options no_notify no_monitor
     mkfifo $PIPE
-    sqlite3 -batch "${HISTDB_FILE}" < $PIPE >/dev/null &|
+    sqlite3 -batch -noheader "${HISTDB_FILE}" < $PIPE >/dev/null &|
     sysopen -w -o cloexec -u HISTDB_FD -- $PIPE
     command rm $PIPE
     HISTDB_INODE=$(zstat +inode ${HISTDB_FILE})


### PR DESCRIPTION
The source of the troubles was that I have `.headers on` in my .sqliterc. First, that was breaking the plugin and second just the fact that there is a .sqliterc, make it always telling me with every command.