### PR TITLE
Fix sql_escape for multiline inputs

### DIFF
--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -22,7 +22,7 @@ typeset -g HISTDB_INSTALLED_IN="${(%):-%N}"
 
 
 sql_escape () {
-    print -r ${${@//\'/\'\'}//$'\x00'}
+    print -r -- ${${@//\'/\'\'}//$'\x00'}
 }
 
 _histdb_query () {


### PR DESCRIPTION
In commit https://github.com/larkery/zsh-histdb/commit/0f6075cee6a11bf38f61eaf842f87e2ce2bbc48f the performance of sql_escape was improved. Unfortunately this new sql_escape breaks on some inputs. If i try to enter the following command, i get the error: `sql_escape:print:1: bad option: -t` after typing the first `t` in context:

```
$ kubectl get pods \
--context
```

My knowledge of variable substitution magic in zsh/bash is limited, but I found that reverting to the old `sql_escape` definition with `sed` does work.