### PR TITLE
Change HISTDB_INODE type to an array

### DIFF
--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -14,7 +14,7 @@ else
     typeset -g HISTDB_FILE
 fi
 
-typeset -g HISTDB_INODE=""
+typeset -g HISTDB_INODE=()
 typeset -g HISTDB_SESSION=""
 typeset -g HISTDB_HOST=""
 typeset -g HISTDB_INSTALLED_IN="${(%):-%N}"


### PR DESCRIPTION
Sourcing `.zshrc` multiple times in the same session leads to the error in #125. `HISTDB_INODE` should be set to an array type to match its later assignment:

```zstat -A HISTDB_INODE +inode ${HISTDB_FILE}```


Fixes #125