### PR TITLE
Add Fig as an installation method

### DIFF
--- a/README.org
+++ b/README.org
@@ -56,7 +56,7 @@ in your zsh startup files.
 
 Install ~zsh-histdb~ with [[https://fig.io][Fig]] in just one click.
 
-[[https://fig.io/badges/install-with-fig.svg][https://fig.io/plugins/other/zsh-histdb]]
+[[https://fig.io/plugins/other/zsh-histdb][https://fig.io/badges/install-with-fig.svg]]
 
 ** Note for OS X users
 

--- a/README.org
+++ b/README.org
@@ -55,7 +55,9 @@ in your zsh startup files.
 
 Install ~zsh-histdb~ with [[https://fig.io][Fig]] in just one click.
 
-[[https://fig.io/badges/install-with-fig.svg]]
+#+MACRO: imglnk @@html:<a href="$1"><img src="$2"></a>@@
+
+{{{imglnk(https://fig.io/plugins/other/zsh-histdb,https://fig.io/badges/install-with-fig.svg)}}}
 
 ** Note for OS X users
 

--- a/README.org
+++ b/README.org
@@ -53,11 +53,10 @@ in your zsh startup files.
 
 ** Fig
 
+
 Install ~zsh-histdb~ with [[https://fig.io][Fig]] in just one click.
 
-#+MACRO: imglnk @@html:<a href="$1"><img src="$2"></a>@@
-
-{{{imglnk(https://fig.io/plugins/other/zsh-histdb,https://fig.io/badges/install-with-fig.svg)}}}
+[[https://fig.io/badges/install-with-fig.svg][https://fig.io/plugins/other/zsh-histdb]]
 
 ** Note for OS X users
 

--- a/README.org
+++ b/README.org
@@ -51,6 +51,12 @@ autoload -Uz add-zsh-hook
 
 in your zsh startup files.
 
+** Fig
+
+Install ~zsh-histdb~ with [[https://fig.io][Fig]] in just one click.
+
+[[https://fig.io/badges/install-with-fig.svg]]
+
 ** Note for OS X users
 
 Add the following line before you source `sqlite-history.zsh`. See https://github.com/larkery/zsh-histdb/pull/31 for details.


### PR DESCRIPTION
We recently listed on `zsh-histdb` on [Fig Plugin Store](https://fig.io/plugins), so we'd love to have Fig displayed as a download method on your readme. Thanks so much and please let me know if you have any questions!