### PR TITLE
Ensure consistent sqlite output mode

### DIFF
--- a/histdb-merge
+++ b/histdb-merge
@@ -9,8 +9,8 @@ local theirs=${1:?three databases required}
 $HERE/histdb-migrate $ancestor # this is always reasonable to do
 $HERE/histdb-migrate $ours # this also seems fine
 
-V_OURS=$(sqlite3 -batch -noheader $ours 'PRAGMA user_version')
-V_THEIRS=$(sqlite3 -batch -noheader $theirs 'PRAGMA user_version')
+V_OURS=$(sqlite3 -batch -noheader -list $ours 'PRAGMA user_version')
+V_THEIRS=$(sqlite3 -batch -noheader -list $theirs 'PRAGMA user_version')
 
 if [[ ${V_OURS} -lt ${V_THEIRS} ]] ; then
     echo "Attempting to merge with a database from a future version (${V_THEIRS})."
@@ -35,7 +35,7 @@ echo "Ancestor has $(sqlite3 ${ancestor} 'select count(*) from history') entries
 echo "We have $(sqlite3 ${ours} 'select count(*) from history') entries"
 echo "Theirs have $(sqlite3 ${theirs} 'select count(*) from history') entries"
 
-sqlite3 -batch -noheader "${theirs}" <<EOF
+sqlite3 -batch -noheader -list "${theirs}" <<EOF
 ATTACH DATABASE '${ours}' AS n;
 ATTACH DATABASE '${ancestor}' AS a;
 

--- a/histdb-migrate
+++ b/histdb-migrate
@@ -4,7 +4,7 @@ typeset -g HISTDB_SCHEMA_VERSION=2
 typeset -g HISTDB_INSTALLED_IN="${(%):-%N}"
 
 local TARGET_FILE="$1"
-local CURRENT_VERSION=$(sqlite3 -batch -noheader "${TARGET_FILE}" 'PRAGMA user_version')
+local CURRENT_VERSION=$(sqlite3 -batch -noheader -list "${TARGET_FILE}" 'PRAGMA user_version')
 if [[ ${CURRENT_VERSION} -lt ${HISTDB_SCHEMA_VERSION} ]]; then
     echo "History database ${TARGET_FILE} is using an older schema (${CURRENT_VERSION}) and will be updated to version ${HISTDB_SCHEMA_VERSION}."
     local MIGRATION_FILENAME="$(dirname ${HISTDB_INSTALLED_IN})/db_migrations/${CURRENT_VERSION}to${HISTDB_SCHEMA_VERSION}.sql"
@@ -12,7 +12,7 @@ if [[ ${CURRENT_VERSION} -lt ${HISTDB_SCHEMA_VERSION} ]]; then
         local BACKUP_FILE="${TARGET_FILE}-$(date +%s).bak"
         echo "Backing up database to ${BACKUP_FILE} before migration"
         cp ${BACKUP_FILE} ${HISTDB_FILE}
-        sqlite3 -batch -noheader "${TARGET_FILE}" < "${MIGRATION_FILENAME}"
+        sqlite3 -batch -noheader -list "${TARGET_FILE}" < "${MIGRATION_FILENAME}"
         local R="$?"
         [[ "$R" -ne 0 ]] && (echo "Error during database conversion"; cp ${BACKUP_FILE} ${HISTDB_FILE}) || echo "Update successful (you may want to remove the backup)"
         return "$R"

--- a/sqlite-history.zsh
+++ b/sqlite-history.zsh
@@ -27,7 +27,7 @@ sql_escape () {
 }
 
 _histdb_query () {
-    sqlite3 -batch -noheader -cmd ".timeout 1000" "${HISTDB_FILE}" "$@"
+    sqlite3 -batch -noheader -list -cmd ".timeout 1000" "${HISTDB_FILE}" "$@"
     [[ "$?" -ne 0 ]] && echo "error in $@"
 }
 
@@ -53,7 +53,7 @@ _histdb_start_sqlite_pipe () {
     local PIPE==(<<<'')
     setopt local_options no_notify no_monitor
     mkfifo $PIPE
-    sqlite3 -batch -noheader "${HISTDB_FILE}" < $PIPE >/dev/null &|
+    sqlite3 -batch -noheader -list "${HISTDB_FILE}" < $PIPE >/dev/null &|
     sysopen -w -o cloexec -u HISTDB_FD -- $PIPE
     command rm $PIPE
     zstat -A HISTDB_INODE +inode ${HISTDB_FILE}


### PR DESCRIPTION
This is another variation on #112. With a non-default output mode in .sqliterc output can have a format that the scripts don't handle. For instance, in my case I have `.mode column` in my .sqliterc. It turns out this meant that when setting up a new machine the output of the HISTDB_SESSION query was an all-whitespace string aligned to the column width (`﻿'              '`) instead of the [expected empty string](https://github.com/larkery/zsh-histdb/blob/90a6c104d0fcc0410d665e148fa7da28c49684eb/sqlite-history.zsh#L100), which meant that the output wasn't substituted with the default value `0`.

The fix here is to add `-list` to the sqlite3 CLI arguments everywhere that #112 modified. This is obviously unfortunate and there are probably other ways that .sqliterc can break things, but unless I'm missing it there's no way to turn the rc file off completely.